### PR TITLE
Add options to default function

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,11 +2,13 @@ import Map from 'es6-map';
 import npmResolve from 'resolve';
 import bowerResolve from 'resolve-bower';
 
+let options = {};
+
 function find(resolver, file) {
 
   return new Promise((resolve) => {
 
-    resolver(file, (err, res) => resolve(err ? file : res));
+    resolver(file, options, (err, res) => resolve(err ? file : res));
 
   });
 
@@ -28,7 +30,9 @@ find.bower = function(file) {
  * Look for Sass files installed through npm
  * @return {Function}         Function to be used by node-sass importer
  */
-export default function() {
+export default function(opts) {
+
+  options = opts || options;
 
   const aliases = new Map();
 

--- a/test.js
+++ b/test.js
@@ -1,5 +1,5 @@
-/*eslint no-unused-expressions: 0, no-var: 0 */
-/*eslint-env node, mocha */
+/* eslint no-unused-expressions: 0, no-var: 0 */
+/* eslint-env node, mocha */
 
 
 import { expect } from 'chai';


### PR DESCRIPTION
This is a tiny change to allow options to be passed into the resolve. In this instance, I needed to change the basedir since I have multiple node_modules folders in the same, larger repo. Spaces in test.js were also causing blocking errors in `npm test`
