### PR TITLE
Fix ESLint errors

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -41,7 +41,13 @@ const bower = (file) => find(bowerResolve, file);
  */
 const read = ({ url, prev, resolved }) => new Promise((resolve, reject) => {
   if (url.match(/\.css$/g)) {
-    fs.readFile(url, 'utf8', (err, contents) => err ? reject(err) : resolve({ contents }));
+    fs.readFile(url, 'utf8', (err, contents) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve({ contents });
+      }
+    });
   } else {
     let resolvedURL = url;
     if (!resolved && prev && prev !== 'stdin' && !path.isAbsolute(url)) {

--- a/test.js
+++ b/test.js
@@ -14,7 +14,13 @@ function getCSS(file, data) {
       importer: moduleImporter({
         basedir: path.join(__dirname, 'fixtures'),
       }),
-    }, (err, res) => err ? reject(err) : resolve(res.css.toString()));
+    }, (err, res) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(res.css.toString());
+      }
+    });
   });
 }
 


### PR DESCRIPTION
Fix for these errors:

/home/travis/build/lucasmotta/sass-module-importer/src/index.js
  42:30  error  Arrow function used ambiguously with a conditional expression  no-confusing-arrow
/home/travis/build/lucasmotta/sass-module-importer/test.js
  17:8  error  Arrow function used ambiguously with a conditional expression  no-confusing-arrow

My previous PR (https://github.com/lucasmotta/sass-module-importer/pull/5) is not the cause of these errors.
