### PR TITLE
Ensure nested dependencies do not overlap each other.

### DIFF
--- a/fixtures/node_modules/test-npm-nested-multiple/folder/_child.scss
+++ b/fixtures/node_modules/test-npm-nested-multiple/folder/_child.scss
@@ -1,0 +1,3 @@
+.child2 {
+  content: 'I am also being imported by another file';
+}

--- a/fixtures/node_modules/test-npm-nested-multiple/main.scss
+++ b/fixtures/node_modules/test-npm-nested-multiple/main.scss
@@ -1,0 +1,6 @@
+/* partial */
+@import "folder/child";
+
+.test2 {
+  content: "MORE SCSS from 'npm' and from 'main' field.";
+}

--- a/fixtures/node_modules/test-npm-nested-multiple/package.json
+++ b/fixtures/node_modules/test-npm-nested-multiple/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "test-npm-nested-multiple",
+  "main": "main.scss"
+}

--- a/src/index.js
+++ b/src/index.js
@@ -21,7 +21,9 @@ class ModuleImporter {
       .then(file => this.bower(file))
       .then(file => this.read(file))
       .then((res) => {
-        this.aliases.set(url, res);
+        if (res.resolved) {
+          this.aliases.set(url, res);
+        }
         return res;
       });
   }

--- a/test.js
+++ b/test.js
@@ -42,6 +42,14 @@ describe('sass-module-importer', () => {
     });
   });
 
+  it('should import nested files or dependencies which have matching nested names', (done) => {
+    getCSS(null, '@import "test-npm-nested";@import "test-npm-nested-multiple";').then((css) => {
+      const expected = `*,*:after,*:before{box-sizing:border-box}html,body{margin:0;padding:0}.test{content:"SCSS from 'npm' and from 'style' field."}.child{content:'I am being imported by another file'}.test{content:"SCSS from 'npm' and from 'main' field."}.child2{content:'I am also being imported by another file'}.test2{content:"MORE SCSS from 'npm' and from 'main' field."}\n`;
+      expect(css).to.exist.and.equal(expected);
+      done();
+    });
+  });
+
   it('should fail to import non-existing module', (done) => {
     getCSS(null, '@import "unicorn";').catch((err) => {
       const expected = {


### PR DESCRIPTION
Potential solution of #11 which basically forgoes caching on nested dependencies to stop them overwriting each other. Caching is still done for resolving top level node dependencies.
