### PR TITLE
Minor tweaks: Throw errors and build on Node 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "node-sass": "^3.4.2",
     "rollup": "^0.25.4",
     "rollup-plugin-buble": "^0.5.0",
-    "rollup-plugin-commonjs": "^2.2.1",
+    "rollup-plugin-commonjs": "^3.1.0",
     "rollup-plugin-json": "^2.0.0",
     "rollup-plugin-node-resolve": "^1.5.0"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -85,6 +85,8 @@ export default function (opts) {
   const importer = new ModuleImporter(opts);
 
   return (url, prev, done) => {
-    importer.resolve({ url, prev }).then(done);
+    importer.resolve({ url, prev })
+      .then(done)
+      .catch(err => setImmediate(() => { throw err; }));
   };
 }


### PR DESCRIPTION
Was looking at making a bigger PR, so started looking at the code and discovered these two improvements before finding out that my bigger PR was a bit harder to achieve than I thought.

Sending you these two anyhow. Sorry for wrapping up two changes in one PR, hope it's okay as they are so minor.

The dependency upgrade is due to https://github.com/rollup/rollup-plugin-commonjs/issues/63
