### PR TITLE
Resolve relative to previous file or current dir

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -38,7 +38,10 @@ class ModuleImporter {
       if (resolved) {
         resolve({ url, prev, resolved });
       } else {
-        resolver(url, this.options, (err, res) => {
+        const options = Object.assign({}, this.options, {
+          basedir: prev && prev !== 'stdin' ? path.dirname(prev) : process.cwd(),
+        });
+        resolver(url, options, (err, res) => {
           resolve({ url: (err ? url : res), prev, resolved: !err });
         });
       }


### PR DESCRIPTION
All module resolves should happen with the previous file as the basedir so that the correct file is found.
