### PR TITLE
tilde supporter for jetBrains IDE

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,9 +14,8 @@ class ModuleImporter {
 
   resolve({ url, prev }) {
     if (url.substring(0, 1) === '~') { // tilde supporter for jetBrains IDE
-      let url = url.substring(1);
+      url = url.substring(1); // eslint-disable-line no-param-reassign
     }
-
     const fullPath = prev === 'stdin' ? url : path.resolve(path.dirname(prev), url);
     const extname = path.extname(fullPath);
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,6 +13,11 @@ class ModuleImporter {
   }
 
   resolve({ url, prev }) {
+    
+    if (url.substring(0, 1) === '~'){ //tilde supporter for jetBrains IDE
+      url = url.substring(1);
+    }
+    
     const fullPath = prev === 'stdin' ? url : path.resolve(path.dirname(prev), url);
     const extname = path.extname(fullPath);
 

--- a/src/index.js
+++ b/src/index.js
@@ -13,11 +13,10 @@ class ModuleImporter {
   }
 
   resolve({ url, prev }) {
-    
-    if (url.substring(0, 1) === '~'){ //tilde supporter for jetBrains IDE
-      url = url.substring(1);
+    if (url.substring(0, 1) === '~') { // tilde supporter for jetBrains IDE
+      let url = url.substring(1);
     }
-    
+
     const fullPath = prev === 'stdin' ? url : path.resolve(path.dirname(prev), url);
     const extname = path.extname(fullPath);
 


### PR DESCRIPTION
Repair "cannot resolve file" error in jetBrains IDE (phpStorm, webStorm, IDEA ...), when importing sass using short file name without path.
~ or "tilde" hides this error.